### PR TITLE
Pass options into collection blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,6 @@ end
 When used with Rails, serializer instances have the `#url_helpers`
 method available.
 
-
 ```ruby
 class ItemSerializer < SimpleSerializer
   attribute :link do
@@ -187,19 +186,24 @@ end
 If you want to pass in options to the serializer you can access via the second argument of the block
 
 
+```ruby
 class MyObjectSerializer < SimpleSerializer
   attribute :id do |object, options|
     options[:prefix] + object.id
   end
 end
-```
+
 MyObjectSerializer.new(object, { prefix: "prefix_" }).serialize
+```
 
 Produces:
 
+```json
 {
-  id: "prefix_id"
+  "id": "prefix_id"
 }
+```
+
 
 ### Attribute Inheritance
 

--- a/lib/simple_serializer.rb
+++ b/lib/simple_serializer.rb
@@ -186,12 +186,10 @@ class SimpleSerializer
     self.class.collections.each do |collection_name, key, serializer, block|
       collection = get_collection(collection_name, block)
 
-      serializer_instance = serializer.new(nil)
       json_array = []
 
       collection.each do |object|
-        serializer_instance.object = object
-        serializer_instance.options = @options
+        serializer_instance = serializer.new(object, @options)
         json_array << serializer_instance.serialize
       end
 
@@ -202,7 +200,7 @@ class SimpleSerializer
   # Get the collection from #object or block, or [] if nil.
   def get_collection(name, block)
     if block
-      instance_exec(@object, &block)
+      instance_exec(@object, @options, &block)
     else
       @object.public_send(name)
     end || []

--- a/spec/simple_serializer_spec.rb
+++ b/spec/simple_serializer_spec.rb
@@ -274,6 +274,22 @@ RSpec.describe SimpleSerializer do
           )
         end
       end
+
+      context 'when options provided to has_many serializer' do
+        it 'passes the options to each serializer' do
+          klass = serializer do
+            has_many :collection_items, serializer: CollectionSerializer do |_, options|
+              options[:override]
+            end
+          end
+          elt3 = TestStruct.new(4, "ELT 3")
+          expect(klass.new(object, { override: [elt3] }).serializable_hash).to eq(
+            collection_items: [
+              { id: 4, name: "ELT 3" }
+            ]
+          )
+        end
+      end
     end
 
     context "when an attribute returns an Array" do


### PR DESCRIPTION
- this also changes the behavior to instantiate a new serializer for
each collection item.
- updates readme to fix styling