### PR TITLE
Instantiate new serializer class for each collection item

### DIFF
--- a/lib/simple_serializer.rb
+++ b/lib/simple_serializer.rb
@@ -78,18 +78,13 @@ class SimpleSerializer
 
   # Serialize #object as a Hash with Symbol keys.
   def serializable_hash(_ = nil)
-    return @object unless @object
+    return nil if @object.nil?
     return serialize_single_object_to_hash unless collection?
+    return [] if @object.empty?
 
-    json = []
-    return json if @object.nil?
-    original_object = @object
-    original_object.each do |object|
-      @object = object
-      json << serialize_single_object_to_hash
+    @object.map do |object|
+      self.class.new(object, @options).serializable_hash
     end
-    @object = original_object
-    json
   end
 
   alias to_hash serializable_hash
@@ -133,10 +128,7 @@ class SimpleSerializer
   private
 
   # Private serialization implementation for a single object.
-  # @object must be set to a single object before calling.
   def serialize_single_object_to_hash
-    return @object unless @object
-
     hash = {}
     serialize_attributes(hash)
     serialize_sub_records(hash)


### PR DESCRIPTION
If you pass in an array of objects, each object should get it's own serializer instance.

Benchmark shows that the performance is not a blocker: 

https://github.com/trevorrjohn/simple_serializer/blob/tj/benchmark/benchmark.rb

```
Rehearsal ------------------------------------------------------------
existing serializer:       0.041254   0.001016   0.042270 (  0.042298)
new instance serializer:   0.036131   0.001481   0.037612 (  0.043380)
--------------------------------------------------- total: 0.079882sec

                               user     system      total        real
existing serializer:       0.031271   0.000368   0.031639 (  0.031770)
new instance serializer:   0.038386   0.002491   0.040877 (  0.047027)
```